### PR TITLE
fix panic when empty test function without t name

### DIFF
--- a/pkg/paralleltest/paralleltest.go
+++ b/pkg/paralleltest/paralleltest.go
@@ -249,7 +249,9 @@ func isTestFunction(funcDecl *ast.FuncDecl) (bool, string) {
 		if selectExpr, ok := starExp.X.(*ast.SelectorExpr); ok {
 			if selectExpr.Sel.Name == testMethodStruct {
 				if s, ok := selectExpr.X.(*ast.Ident); ok {
-					return s.Name == testMethodPackageType, param.Names[0].Name
+					if len(param.Names) > 0 {
+						return s.Name == testMethodPackageType, param.Names[0].Name
+					}
 				}
 			}
 		}

--- a/pkg/paralleltest/testdata/src/i/i_test.go
+++ b/pkg/paralleltest/testdata/src/i/i_test.go
@@ -44,6 +44,9 @@ func TestFunctionSuccessfulNoRangeTest(t *testing.T) {
 }
 
 func TestFunctionMissingCallToParallel(t *testing.T) {}
+
+func TestFunctionWithoutTMissingCallToParallel(*testing.T) {}
+
 func TestFunctionRangeMissingCallToParallel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
The PR fixes panic when running `paralleltest` on an empty test function without `t`.

This bug was discovered when running `golangci-lint run --disable-all --no-config --enable=paralleltest runtime/logging/source_test.go` in [`ServiceWeaver/weaver`](https://github.com/ServiceWeaver/weaver) on the [following lines](https://github.com/ServiceWeaver/weaver/blob/9c711d67c286e1b7a8cabd2f2d99579861ac6906/runtime/logging/source_test.go#L87):
```
func TestDontShowWholeFile(*testing.T) {}
```
---

Without the change test `TestIgnoreMissing` panics:
```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestIgnoreMissing$ github.com/kunwardeep/paralleltest/pkg/paralleltest -count=1 -v -race

=== RUN   TestIgnoreMissing
=== PAUSE TestIgnoreMissing
=== CONT  TestIgnoreMissing
panic: runtime error: index out of range [0] with length 0

goroutine 1124 [running]:
github.com/kunwardeep/paralleltest/pkg/paralleltest.isTestFunction(0xc00abf7ce0)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/pkg/paralleltest/paralleltest.go:252 +0x393
github.com/kunwardeep/paralleltest/pkg/paralleltest.run.func1({0x14ed048?, 0xc00abf7ce0?})
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/pkg/paralleltest/paralleltest.go:58 +0x1b8
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc007bcb890, {0xc007bcb880?, 0x1, 0x1?}, 0xc007bcb8a8)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/vendor/golang.org/x/tools/go/ast/inspector/inspector.go:77 +0x103
github.com/kunwardeep/paralleltest/pkg/paralleltest.run(0xc00b962410)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/pkg/paralleltest/paralleltest.go:47 +0x1c6
golang.org/x/tools/go/analysis/internal/checker.(*action).execOnce(0xc00b8e70e0)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:728 +0x1a25
sync.(*Once).doSlow(0xc00b8e70e0, 0xc000611f68)
	/usr/local/Cellar/go/1.20.1/libexec/src/sync/once.go:74 +0x102
sync.(*Once).Do(0xc00b8e70e0, 0x10bfbd9?)
	/usr/local/Cellar/go/1.20.1/libexec/src/sync/once.go:65 +0x47
golang.org/x/tools/go/analysis/internal/checker.(*action).exec(0xc00b8e70e0)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:616 +0x4d
golang.org/x/tools/go/analysis/internal/checker.execAll.func1(0x0?)
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:604 +0x36
created by golang.org/x/tools/go/analysis/internal/checker.execAll
	/Users/redko.o/src/github.com/kunwardeep/paralleltest/vendor/golang.org/x/tools/go/analysis/internal/checker/checker.go:610 +0x22f
FAIL	github.com/kunwardeep/paralleltest/pkg/paralleltest	2.325s
```