### PR TITLE
Add option `ignoremissingsubtests` to ignore missing `t.Parallel()` in subtests

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@ The Go linter `paralleltest` checks that the t.Parallel gets called for the test
 paralleltest ./...
 ```
 
-To ignore missing calls to `t.Parallel` and only report incorrect uses of it, pass the flag `-i`.
+A few options can be activated by flag:
+
+* `-i`: Ignore missing calls to `t.Parallel` and only report incorrect uses of it.
+* `-ignoremissingsubtests`: Require that top-level tests specify `t.Parallel`, but don't require it in subtests (`t.Run(...)`).
 
 ## Examples
 

--- a/main.go
+++ b/main.go
@@ -7,5 +7,5 @@ import (
 )
 
 func main() {
-	singlechecker.Main(paralleltest.Analyzer)
+	singlechecker.Main(paralleltest.NewAnalyzer())
 }

--- a/pkg/paralleltest/paralleltest.go
+++ b/pkg/paralleltest/paralleltest.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"golang.org/x/tools/go/analysis"
-	"golang.org/x/tools/go/analysis/passes/inspect"
 	"golang.org/x/tools/go/ast/inspector"
 )
 
@@ -16,28 +15,36 @@ It also checks that the t.Parallel is used if multiple tests cases are run as pa
 As part of ensuring parallel tests works as expected it checks for reinitialising of the range value
 over the test cases.(https://tinyurl.com/y6555cy6)`
 
-var Analyzer = &analysis.Analyzer{
-	Name:     "paralleltest",
-	Doc:      Doc,
-	Run:      run,
-	Flags:    flags(),
-	Requires: []*analysis.Analyzer{inspect.Analyzer},
+func NewAnalyzer() *analysis.Analyzer {
+	return newParallelAnalyzer().analyzer
 }
 
-const ignoreMissingFlag = "i"
-
-func flags() flag.FlagSet {
-	options := flag.NewFlagSet("", flag.ExitOnError)
-	options.Bool(ignoreMissingFlag, false, "ignore missing calls to t.Parallel")
-	return *options
+// parallelAnalyzer is an internal analyzer that makes options available to a
+// run pass. It wraps an `analysis.Analyzer` that should be returned for
+// linters.
+type parallelAnalyzer struct {
+	analyzer              *analysis.Analyzer
+	ignoreMissing         bool
+	ignoreMissingSubtests bool
 }
 
-type boolValue bool
+func newParallelAnalyzer() *parallelAnalyzer {
+	a := &parallelAnalyzer{}
 
-func run(pass *analysis.Pass) (interface{}, error) {
+	var flags flag.FlagSet
+	flags.BoolVar(&a.ignoreMissing, "i", false, "ignore missing calls to t.Parallel")
+	flags.BoolVar(&a.ignoreMissingSubtests, "ignoremissingsubtests", false, "ignore missing calls to t.Parallel in subtests")
 
-	ignoreMissing := pass.Analyzer.Flags.Lookup(ignoreMissingFlag).Value.(flag.Getter).Get().(bool)
+	a.analyzer = &analysis.Analyzer{
+		Name:  "paralleltest",
+		Doc:   Doc,
+		Run:   a.run,
+		Flags: flags,
+	}
+	return a
+}
 
+func (a *parallelAnalyzer) run(pass *analysis.Pass) (interface{}, error) {
 	inspector := inspector.New(pass.Files)
 
 	nodeFilter := []ast.Node{
@@ -127,13 +134,13 @@ func run(pass *analysis.Pass) (interface{}, error) {
 			}
 		}
 
-		if !ignoreMissing && !funcHasParallelMethod {
+		if !a.ignoreMissing && !funcHasParallelMethod {
 			pass.Reportf(node.Pos(), "Function %s missing the call to method parallel\n", funcDecl.Name.Name)
 		}
 
 		if rangeStatementOverTestCasesExists && rangeNode != nil {
 			if !rangeStatementHasParallelMethod {
-				if !ignoreMissing {
+				if !a.ignoreMissing && !a.ignoreMissingSubtests {
 					pass.Reportf(rangeNode.Pos(), "Range statement for test %s missing the call to method parallel in test Run\n", funcDecl.Name.Name)
 				}
 			} else if loopVariableUsedInRun != nil {
@@ -142,7 +149,7 @@ func run(pass *analysis.Pass) (interface{}, error) {
 		}
 
 		// Check if the t.Run is more than one as there is no point making one test parallel
-		if !ignoreMissing {
+		if !a.ignoreMissing && !a.ignoreMissingSubtests {
 			if numberOfTestRun > 1 && len(positionOfTestRunNode) > 0 {
 				for _, n := range positionOfTestRunNode {
 					pass.Reportf(n.Pos(), "Function %s missing the call to method parallel in the test run\n", funcDecl.Name.Name)

--- a/pkg/paralleltest/paralleltest_test.go
+++ b/pkg/paralleltest/paralleltest_test.go
@@ -1,7 +1,6 @@
 package paralleltest
 
 import (
-	"flag"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,10 +17,10 @@ func TestMissing(t *testing.T) {
 	}
 
 	testdata := filepath.Join(filepath.Dir(wd), "paralleltest", "testdata")
-	analysistest.Run(t, testdata, Analyzer, "t")
+	analysistest.Run(t, testdata, NewAnalyzer(), "t")
 }
 
-func TestIgnoreMissing(t *testing.T) {
+func TestIgnoreMissingOption(t *testing.T) {
 	t.Parallel()
 
 	wd, err := os.Getwd()
@@ -29,12 +28,24 @@ func TestIgnoreMissing(t *testing.T) {
 		t.Fatalf("Failed to get wd: %s", err)
 	}
 
-	options := flag.NewFlagSet("", flag.ExitOnError)
-	options.Bool("i", true, "")
-
-	analyzer := *Analyzer
-	analyzer.Flags = *options
+	a := newParallelAnalyzer()
+	a.ignoreMissing = true
 
 	testdata := filepath.Join(filepath.Dir(wd), "paralleltest", "testdata")
-	analysistest.Run(t, testdata, &analyzer, "i")
+	analysistest.Run(t, testdata, a.analyzer, "i")
+}
+
+func TestIgnoreMissingSubtestsOption(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get wd: %s", err)
+	}
+
+	a := newParallelAnalyzer()
+	a.ignoreMissingSubtests = true
+
+	testdata := filepath.Join(filepath.Dir(wd), "paralleltest", "testdata")
+	analysistest.Run(t, testdata, a.analyzer, "ignoremissingsubtests")
 }

--- a/pkg/paralleltest/testdata/src/ignoremissingsubtests/ignoremissingsubtests_test.go
+++ b/pkg/paralleltest/testdata/src/ignoremissingsubtests/ignoremissingsubtests_test.go
@@ -1,0 +1,163 @@
+package t
+
+import (
+	"fmt"
+	"testing"
+)
+
+func NoATestFunction()                                  {}
+func TestingFunctionLooksLikeATestButIsNotWithParam()   {}
+func TestingFunctionLooksLikeATestButIsWithParam(i int) {}
+func AbcFunctionSuccessful(t *testing.T)                {}
+
+func TestFunctionSuccessfulRangeTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(x *testing.T) {
+			x.Parallel()
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestFunctionSuccessfulNoRangeTest(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+	}{{name: "foo"}, {name: "bar"}}
+
+	t.Run(testCases[0].name, func(t *testing.T) {
+		t.Parallel()
+		fmt.Println(testCases[0].name)
+	})
+	t.Run(testCases[1].name, func(t *testing.T) {
+		t.Parallel()
+		fmt.Println(testCases[1].name)
+	})
+
+}
+
+func TestFunctionMissingCallToParallel(t *testing.T) {} // want "Function TestFunctionMissingCallToParallel missing the call to method parallel"
+func TestFunctionRangeMissingCallToParallel(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+
+	// this range loop should be okay as it does not have test Run
+	for _, tc := range testCases {
+		fmt.Println(tc.name)
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestFunctionMissingCallToParallelAndRangeNotUsingRangeValueInTDotRun(t *testing.T) { // want "Function TestFunctionMissingCallToParallelAndRangeNotUsingRangeValueInTDotRun missing the call to method parallel"
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestFunctionRangeNotUsingRangeValueInTDotRun(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+	for _, tc := range testCases { // want "Range statement for test TestFunctionRangeNotUsingRangeValueInTDotRun does not reinitialise the variable tc"
+		t.Run("tc.name", func(t *testing.T) {
+			t.Parallel()
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestFunctionRangeNotReInitialisingVariable(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name string
+	}{{name: "foo"}}
+	for _, tc := range testCases { // want "Range statement for test TestFunctionRangeNotReInitialisingVariable does not reinitialise the variable tc"
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			fmt.Println(tc.name)
+		})
+	}
+}
+
+func TestFunctionTwoTestRunMissingCallToParallel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("1", func(t *testing.T) {
+		fmt.Println("1")
+	})
+	t.Run("2", func(t *testing.T) {
+		fmt.Println("2")
+	})
+}
+
+func TestFunctionFirstOneTestRunMissingCallToParallel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("1", func(t *testing.T) {
+		fmt.Println("1")
+	})
+	t.Run("2", func(t *testing.T) {
+		t.Parallel()
+		fmt.Println("2")
+	})
+}
+
+func TestFunctionSecondOneTestRunMissingCallToParallel(t *testing.T) {
+	t.Parallel()
+
+	t.Run("1", func(x *testing.T) {
+		x.Parallel()
+		fmt.Println("1")
+	})
+	t.Run("2", func(t *testing.T) {
+		fmt.Println("2")
+	})
+}
+
+type notATest int
+
+func (notATest) Run(args ...interface{}) {}
+func (notATest) Parallel()               {}
+
+func TestFunctionWithRunLookalike(t *testing.T) {
+	t.Parallel()
+
+	var other notATest
+	// These aren't t.Run, so they shouldn't be flagged as Run invocations missing calls to Parallel.
+	other.Run(1, 1)
+	other.Run(2, 2)
+}
+
+func TestFunctionWithParallelLookalike(t *testing.T) { // want "Function TestFunctionWithParallelLookalike missing the call to method parallel"
+	var other notATest
+	// This isn't t.Parallel, so it doesn't qualify as a call to Parallel.
+	other.Parallel()
+}
+
+func TestFunctionWithOtherTestingVar(q *testing.T) {
+	q.Parallel()
+}


### PR DESCRIPTION
In our codebase we've coded ourselves into a bit of a corner wherein
although all our top-level tests are safe to run concurrently, subtests
_within_ any particular test are not due to the use of a shared set of
variables. It'd be nice to fix this of course, but doing so would
involved changing thousands of tests and many dozens of hours of work.

For any Go project, if you've managed to get to a place where all your
top-level tests within a package can run in parallel, that's pretty
good. You might not get the same granularity of work balancing that you
would if all your subtests were parallel too, but (depending somewhat on
the variance in timing between your tests) it gets like you like 80% of
the way there.

So here, I propose that the package adds a new `-ignoremissingsubtests`
flag. It's similar to the existing `-i`, but only ignores missing calls
to `t.Parallel` in subtests and ranges.