### PR TITLE
feat: add ignoreloopvar option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A few options can be activated by flag:
 
 * `-i`: Ignore missing calls to `t.Parallel` and only report incorrect uses of it.
 * `-ignoremissingsubtests`: Require that top-level tests specify `t.Parallel`, but don't require it in subtests (`t.Run(...)`).
+* `-ignoreloopVar`: Ignore loop variable detection.
 
 ## Examples
 

--- a/pkg/paralleltest/paralleltest.go
+++ b/pkg/paralleltest/paralleltest.go
@@ -26,6 +26,7 @@ type parallelAnalyzer struct {
 	analyzer              *analysis.Analyzer
 	ignoreMissing         bool
 	ignoreMissingSubtests bool
+	ignoreLoopVar         bool
 }
 
 func newParallelAnalyzer() *parallelAnalyzer {
@@ -34,6 +35,7 @@ func newParallelAnalyzer() *parallelAnalyzer {
 	var flags flag.FlagSet
 	flags.BoolVar(&a.ignoreMissing, "i", false, "ignore missing calls to t.Parallel")
 	flags.BoolVar(&a.ignoreMissingSubtests, "ignoremissingsubtests", false, "ignore missing calls to t.Parallel in subtests")
+	flags.BoolVar(&a.ignoreLoopVar, "ignoreloopVar", false, "ignore loop variable detection")
 
 	a.analyzer = &analysis.Analyzer{
 		Name:  "paralleltest",
@@ -137,7 +139,7 @@ func (a *parallelAnalyzer) run(pass *analysis.Pass) (interface{}, error) {
 								rangeStatementCantParallelMethod = methodSetenvIsCalledInMethodRun(r.X, innerTestVar)
 							}
 
-							if loopVariableUsedInRun == nil {
+							if !a.ignoreLoopVar && loopVariableUsedInRun == nil {
 								if run, ok := r.X.(*ast.CallExpr); ok {
 									loopVariableUsedInRun = loopVarReferencedInRun(run, loopVars, pass.TypesInfo)
 								}


### PR DESCRIPTION
Fixes #34

I didn't create something based on build tags because inside golangci-lint we need to be on compatible with go.21 builds.